### PR TITLE
Upgrade Go version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Updated Go version from 1.24 to 1.26 in workflow.